### PR TITLE
update nginx install.yml playbook

### DIFF
--- a/playbooks/nginx/install.yml
+++ b/playbooks/nginx/install.yml
@@ -60,7 +60,7 @@
         insertbefore: BOF
     
     - name: backup existing config file
-      command: mv /etc/nginx/nginx.conf /etc/nginx/nginx.conf.old
+      command: cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.old
   
     - name: upload the nginx config file
       copy:


### PR DESCRIPTION
There's an issue with the "backup existing config file" step. It can only be performed successfully once. 

If a student makes a mistake, and uses a wrong path in "upload the nginx config file" step, then next time (after fixing t he path) the script will always fail, because the  "backup existing config file" step will try to move file which no longer exists. 


To solve this issue: 
Replacing
    - name: backup existing config file
      command: mv /etc/nginx/nginx.conf /etc/nginx/nginx.conf.old
with
    - name: backup existing config file
      command: cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.old